### PR TITLE
Cache Tarpaulin

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -11,12 +11,11 @@ env:
 
 jobs:
   Tests-and-Coverage:
-    runs-on: ubuntu-latest
+    runs-on:                    ubuntu-latest
+    container:
+      image:                    xd009642/tarpaulin:develop-nightly
+      options:                  --security-opt seccomp=unconfined
     steps:
     - uses: actions/checkout@v3
     - name: Run tests
-      run: cargo test --verbose
-    # - name: Install tarpaulin
-    #   run: cargo install cargo-tarpaulin
-    # - name: Run tests
-    #   run: cargo tarpaulin --fail-under 100
+      run: cargo tarpaulin --fail-under 100


### PR DESCRIPTION
Tarpaulin takes ~5 minutes to install each time the workflow is run. Seeing if we can use a docker container with it cached to speed things up.