### PR TITLE
Cycle Accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If this project helps you write your own emulator or learn Rust, then even bette
 
 ## CPU Status
 
-192/256 opcodes implemented
+227/256 opcodes implemented
 
 - [x] 151 Official opcodes
 - [ ] 105 Illegal opcodes

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If this project helps you write your own emulator or learn Rust, then even bette
 
 ## CPU Status
 
-151/256 opcodes implemented
+174/256 opcodes implemented
 
 - [x] 151 Official opcodes
 - [ ] 105 Illegal opcodes

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If this project helps you write your own emulator or learn Rust, then even bette
 
 ## CPU Status
 
-174/256 opcodes implemented
+192/256 opcodes implemented
 
 - [x] 151 Official opcodes
 - [ ] 105 Illegal opcodes

--- a/nestest_diff.sh
+++ b/nestest_diff.sh
@@ -1,2 +1,2 @@
 cargo r roms/nestest.nes -c -d > logs/output.log
-diff -y logs/output.log logs/nestest_no_cycle.log > diff.diff
+diff -y logs/output.log logs/nestest_no_ppu.log > diff.diff

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -11,6 +11,7 @@ const ROM_SPACE_END: u16 = 0xFFFF;
 pub struct Bus {
   cpu_vram: [u8; 2048],
   rom: ROM,
+  cycles: usize
 }
 
 impl Bus {
@@ -18,7 +19,8 @@ impl Bus {
   pub fn new(rom: ROM) -> Self {
     Bus {
       cpu_vram: [0; 2048],
-      rom
+      rom,
+      cycles: 7
     }
   }
 
@@ -32,6 +34,18 @@ impl Bus {
 
     self.rom.prg_rom[addr as usize]
 
+  }
+
+  pub fn tick(&mut self) {
+    self.tick_cycles(1);
+  }
+
+  pub fn tick_cycles(&mut self, cycles: u8) {
+    self.cycles += cycles as usize;
+  }
+
+  pub fn get_cycles(&self) -> usize {
+    self.cycles
   }
 
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -206,6 +206,7 @@ impl CPU {
                 0x85 | 0x95 | 0x8D | 0x9D | 0x99 | 0x81 | 0x91 => self.store_register(&ins.addressing_mode, &RegisterID::ACC),
                 0x86 | 0x96 | 0x8E => self.store_register(&ins.addressing_mode, &RegisterID::X),
                 0x84 | 0x94 | 0x8C => self.store_register(&ins.addressing_mode, &RegisterID::Y),
+                0xA3 | 0xA7 | 0xAF | 0xB3 | 0xB7 | 0xBF => self.load_registers(&ins.addressing_mode, &RegisterID::ACC, &RegisterID::X),
                 0xAA => self.transfer_register(&RegisterID::ACC, &RegisterID::X),
                 0xA8 => self.transfer_register(&RegisterID::ACC, &RegisterID::Y),
                 0xBA => self.transfer_register(&RegisterID::SP, &RegisterID::X),
@@ -670,6 +671,12 @@ impl CPU {
         let address = self.get_operand_address(addressing_mode);
         self.mem_write_u8(address, register_value);
 
+    }
+
+    // TODO: Maybe do this manually? Removes the extra setting of the zero and negative flags
+    fn load_registers(&mut self, addressing_mode: &AddressingMode, reg_a: &RegisterID, reg_b: &RegisterID) {
+        self.load_register(addressing_mode, reg_a);
+        self.load_register(addressing_mode, reg_b);
     }
 
     fn transfer_register(&mut self, source_register: &RegisterID, target_register: &RegisterID) {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -173,7 +173,7 @@ impl CPU {
         let ins_set = &(*instructions::CPU_INSTRUCTION_SET);
 
         // TODO REMOVE LATER
-        // println!("IMPLEMENTED {} OF 256 INSTRUCTIONS", ins_set.len());
+        println!("IMPLEMENTED {} OF 256 INSTRUCTIONS", ins_set.len());
 
         loop {
 
@@ -189,6 +189,10 @@ impl CPU {
 
                 0x00 => return,
                 0xEA => (),
+                0x1A | 0x3A | 0x5A | 0x7A | 0xDA | 0xFA => (),
+                0x80 => (),
+                0x1C | 0x3C | 0x5C | 0x7C | 0xDC | 0xFC => self.nop_read(&ins.addressing_mode),
+                0x04 | 0x44 | 0x64 | 0x0C | 0x14 | 0x34 | 0x54 | 0x74 | 0xD4 | 0xF4 => self.nop_read(&ins.addressing_mode),
                 0x69 | 0x65 | 0x75 | 0x6D | 0x7D | 0x79 | 0x61 | 0x71 => self.add_with_carry(&ins.addressing_mode),
                 0xE9 | 0xE5 | 0xF5 | 0xED | 0xFD | 0xF9 | 0xE1 | 0xF1 => self.subtract_with_carry(&ins.addressing_mode),
                 0x29 | 0x25 | 0x35 | 0x2D | 0x3D | 0x39 | 0x21 | 0x31 => self.and(&ins.addressing_mode),
@@ -725,6 +729,11 @@ impl CPU {
         self.conditional_flag_set(data & NEGATIVE_FLAG == NEGATIVE_FLAG, NEGATIVE_FLAG);
         self.conditional_flag_set(result == 0, ZERO_FLAG);
 
+    }
+
+    fn nop_read(&self, addressing_mode: &AddressingMode) {
+        let addr = self.get_operand_address(addressing_mode);
+        self.mem_read_u8(addr);
     }
 
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -173,7 +173,7 @@ impl CPU {
         let ins_set = &(*instructions::CPU_INSTRUCTION_SET);
 
         // TODO REMOVE LATER
-        println!("IMPLEMENTED {} OF 256 INSTRUCTIONS", ins_set.len());
+        // println!("IMPLEMENTED {} OF 256 INSTRUCTIONS", ins_set.len());
 
         loop {
 
@@ -193,13 +193,8 @@ impl CPU {
                 0x80 => (),
                 0x1C | 0x3C | 0x5C | 0x7C | 0xDC | 0xFC => self.nop_read(&ins.addressing_mode),
                 0x04 | 0x44 | 0x64 | 0x0C | 0x14 | 0x34 | 0x54 | 0x74 | 0xD4 | 0xF4 => self.nop_read(&ins.addressing_mode),
-                0x1A | 0x3A | 0x5A | 0x7A | 0xDA | 0xFA => (),
-                0x80 => (),
-                0x1C | 0x3C | 0x5C | 0x7C | 0xDC | 0xFC => self.nop_read(&ins.addressing_mode),
-                0x04 | 0x44 | 0x64 | 0x0C | 0x14 | 0x34 | 0x54 | 0x74 | 0xD4 | 0xF4 => self.nop_read(&ins.addressing_mode),
                 0x69 | 0x65 | 0x75 | 0x6D | 0x7D | 0x79 | 0x61 | 0x71 => self.add_with_carry(&ins.addressing_mode),
                 0xE9 | 0xE5 | 0xF5 | 0xED | 0xFD | 0xF9 | 0xE1 | 0xF1 => self.subtract_with_carry(&ins.addressing_mode),
-                0xEB => self.subtract_with_carry(&ins.addressing_mode),
                 0xEB => self.subtract_with_carry(&ins.addressing_mode),
                 0x29 | 0x25 | 0x35 | 0x2D | 0x3D | 0x39 | 0x21 | 0x31 => self.and(&ins.addressing_mode),
                 0x24 | 0x2C => self.bit(&ins.addressing_mode),
@@ -212,8 +207,6 @@ impl CPU {
                 0x85 | 0x95 | 0x8D | 0x9D | 0x99 | 0x81 | 0x91 => self.store_register(&ins.addressing_mode, &RegisterID::ACC),
                 0x86 | 0x96 | 0x8E => self.store_register(&ins.addressing_mode, &RegisterID::X),
                 0x84 | 0x94 | 0x8C => self.store_register(&ins.addressing_mode, &RegisterID::Y),
-                0xA3 | 0xA7 | 0xAF | 0xB3 | 0xB7 | 0xBF => self.load_registers(&ins.addressing_mode, &RegisterID::ACC, &RegisterID::X),
-                0x83 | 0x87 | 0x8F | 0x97 => self.store_registers(&ins.addressing_mode, &RegisterID::ACC, &RegisterID::X),
                 0xA3 | 0xA7 | 0xAF | 0xB3 | 0xB7 | 0xBF => self.load_registers(&ins.addressing_mode, &RegisterID::ACC, &RegisterID::X),
                 0x83 | 0x87 | 0x8F | 0x97 => self.store_registers(&ins.addressing_mode, &RegisterID::ACC, &RegisterID::X),
                 0xAA => self.transfer_register(&RegisterID::ACC, &RegisterID::X),
@@ -237,16 +230,10 @@ impl CPU {
                 0xC6 | 0xD6 | 0xCE | 0xDE => self.decrement_memory(&ins.addressing_mode),
                 0xC3 | 0xC7 | 0xCF | 0xD3 | 0xD7 | 0xDB | 0xDF => self.decrement_memory_unofficial(&ins.addressing_mode),
                 0xE3 | 0xE7 | 0xEF | 0xF3 | 0xF7 | 0xFB | 0xFF  => self.increment_mem_and_subtract_from_acc(&ins.addressing_mode),
-                0xC3 | 0xC7 | 0xCF | 0xD3 | 0xD7 | 0xDB | 0xDF => self.decrement_memory_unofficial(&ins.addressing_mode),
-                0xE3 | 0xE7 | 0xEF | 0xF3 | 0xF7 | 0xFB | 0xFF  => self.increment_mem_and_subtract_from_acc(&ins.addressing_mode),
                 0x0A => self.acc_shift_left(),
                 0x4A => self.acc_shift_right(),
                 0x2A => self.rotate_acc_left(),
                 0x6A => self.rotate_acc_right(),
-                0x03 | 0x07 | 0x0F | 0x13 | 0x17 | 0x1B | 0x1F => self.arithmetic_shift_left_and_or_with_acc(&ins.addressing_mode),
-                0x43 | 0x47 | 0x4F | 0x53 | 0x57 | 0x5B | 0x5F => self.logical_shift_right_and_xor_with_acc(&ins.addressing_mode),
-                0x23 | 0x27 | 0x2F | 0x33 | 0x37 | 0x3B | 0x3F => self.rotate_left_and_and_with_acc(&ins.addressing_mode),
-                0x63 | 0x67 | 0x6F | 0x73 | 0x77 | 0x7B | 0x7F => self.rotate_right_and_add_to_acc(&ins.addressing_mode),
                 0x03 | 0x07 | 0x0F | 0x13 | 0x17 | 0x1B | 0x1F => self.arithmetic_shift_left_and_or_with_acc(&ins.addressing_mode),
                 0x43 | 0x47 | 0x4F | 0x53 | 0x57 | 0x5B | 0x5F => self.logical_shift_right_and_xor_with_acc(&ins.addressing_mode),
                 0x23 | 0x27 | 0x2F | 0x33 | 0x37 | 0x3B | 0x3F => self.rotate_left_and_and_with_acc(&ins.addressing_mode),

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -235,6 +235,9 @@ impl CPU {
                 0x2A => self.rotate_acc_left(),
                 0x6A => self.rotate_acc_right(),
                 0x03 | 0x07 | 0x0F | 0x13 | 0x17 | 0x1B | 0x1F => self.arithmetic_shift_left_and_or_with_acc(&ins.addressing_mode),
+                0x43 | 0x47 | 0x4F | 0x53 | 0x57 | 0x5B | 0x5F => self.logical_shift_right_and_xor_with_acc(&ins.addressing_mode),
+                0x23 | 0x27 | 0x2F | 0x33 | 0x37 | 0x3B | 0x3F => self.rotate_left_and_and_with_acc(&ins.addressing_mode),
+                0x63 | 0x67 | 0x6F | 0x73 | 0x77 | 0x7B | 0x7F => self.rotate_right_and_add_to_acc(&ins.addressing_mode),
                 0x06 | 0x16 | 0x0E | 0x1E => self.mem_shift_left(&ins.addressing_mode),
                 0x46 | 0x56 | 0x4E | 0x5E => self.mem_shift_right(&ins.addressing_mode),
                 0x26 | 0x36 | 0x2E | 0x3E => self.rotate_mem_left(&ins.addressing_mode),
@@ -644,6 +647,23 @@ impl CPU {
     fn arithmetic_shift_left_and_or_with_acc(&mut self, addressing_mode: &AddressingMode) {
         self.mem_shift_left(addressing_mode);
         self.inclusive_or(addressing_mode)
+    }
+
+    fn logical_shift_right_and_xor_with_acc(&mut self, addressing_mode: &AddressingMode) {
+        self.mem_shift_right(addressing_mode);
+        self.exclusive_or(addressing_mode);
+    }
+
+    fn rotate_left_and_and_with_acc(&mut self, addressing_mode: &AddressingMode) {
+        self.rotate_mem_left(addressing_mode);
+        self.and(addressing_mode)
+    }
+
+    fn rotate_right_and_add_to_acc(&mut self, addressing_mode: &AddressingMode) {
+        self.rotate_mem_right(addressing_mode);
+        let target_addr = self.get_operand_address(addressing_mode);
+        let data = self.mem_read_u8(target_addr);
+        self.add_to_acc(data);
     }
 
     fn set_flag(&mut self, flag_alias: u8) {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -173,7 +173,7 @@ impl CPU {
         let ins_set = &(*instructions::CPU_INSTRUCTION_SET);
 
         // TODO REMOVE LATER
-        println!("IMPLEMENTED {} OF 256 INSTRUCTIONS", ins_set.len());
+        // println!("IMPLEMENTED {} OF 256 INSTRUCTIONS", ins_set.len());
 
         loop {
 
@@ -264,26 +264,37 @@ impl CPU {
 
             }
 
+            self.bus.tick_cycles(ins.cycles);
+
             if current_pc == self.pc {
                 self.pc += (ins.bytes-1) as u16;
             }
         }
     }
 
-    fn get_operand_address(&self, addressing_mode: &AddressingMode) -> u16 {
+    fn get_operand_address(&self, addressing_mode: &AddressingMode) -> (u16, bool) {
         self.get_absolute_address(addressing_mode, self.pc)
     }
 
-    pub fn get_absolute_address(&self, addressing_mode: &AddressingMode, addr: u16) -> u16 {
+    pub fn get_absolute_address(&self, addressing_mode: &AddressingMode, addr: u16) -> (u16, bool) {
+        
         match addressing_mode {
 
-            AddressingMode::Immediate => addr,
-            AddressingMode::Absolute => self.mem_read_u16(addr),
-            AddressingMode::AbsoluteX => self.mem_read_u16(addr).wrapping_add(self.x as u16),
-            AddressingMode::AbsoluteY => self.mem_read_u16(addr).wrapping_add(self.y as u16),
-            AddressingMode::ZeroPage => self.mem_read_u8(addr) as u16,
-            AddressingMode::ZeroPageX => self.mem_read_u8(addr).wrapping_add(self.x) as u16,
-            AddressingMode::ZeroPageY => self.mem_read_u8(addr).wrapping_add(self.y) as u16,
+            AddressingMode::Immediate => (addr, false),
+            AddressingMode::Absolute => (self.mem_read_u16(addr), false),
+            AddressingMode::AbsoluteX => {
+                let base_addr = self.mem_read_u16(addr);
+                let target_addr = base_addr.wrapping_add(self.x as u16);
+                (target_addr, self.page_crossed(base_addr, target_addr))
+            },
+            AddressingMode::AbsoluteY => {
+                let base_addr = self.mem_read_u16(addr);
+                let target_addr = base_addr.wrapping_add(self.y as u16);
+                (target_addr, self.page_crossed(base_addr, target_addr))
+            },
+            AddressingMode::ZeroPage => (self.mem_read_u8(addr) as u16, false),
+            AddressingMode::ZeroPageX => (self.mem_read_u8(addr).wrapping_add(self.x) as u16, false),
+            AddressingMode::ZeroPageY => (self.mem_read_u8(addr).wrapping_add(self.y) as u16, false),
             AddressingMode::Indirect => {
 
                 let target_addr = self.mem_read_u16(addr);
@@ -291,9 +302,9 @@ impl CPU {
                 if target_addr & 0xFF == 0xFF {
                     let lsb = self.mem_read_u8(target_addr);
                     let msb = self.mem_read_u8(target_addr & 0xFF00);
-                    (msb as u16) << 8 | lsb as u16
+                    ((msb as u16) << 8 | lsb as u16, false)
                 } else {
-                    self.mem_read_u16(target_addr)
+                    (self.mem_read_u16(target_addr), false)
                 }
 
             },
@@ -305,7 +316,7 @@ impl CPU {
                 let lsb = self.mem_read_u8(offset_addr as u16);
                 let msb = self.mem_read_u8(offset_addr.wrapping_add(1) as u16);
 
-                (msb as u16) << 8 | lsb as u16
+                ((msb as u16) << 8 | lsb as u16, false)
 
             },
             AddressingMode::IndirectY => {
@@ -314,14 +325,15 @@ impl CPU {
 
                 let lsb = self.mem_read_u8(initial_read_addr as u16);
                 let msb = self.mem_read_u8(initial_read_addr.wrapping_add(1) as u16);
-                let target_addr = (msb as u16) << 8 | lsb as u16;
+                let target_addr_base = (msb as u16) << 8 | lsb as u16;
+                let target_addr = target_addr_base.wrapping_add(self.y as u16);
 
-                target_addr.wrapping_add(self.y as u16)
+                (target_addr, self.page_crossed(target_addr_base, target_addr))
 
             },
             AddressingMode::Relative => {
                 let offset = self.mem_read_u8(addr) as i8;
-                addr.wrapping_add_signed(offset as i16).wrapping_add(1)
+                (addr.wrapping_add_signed(offset as i16).wrapping_add(1), false)
             }
             _ => panic!("Addressing mode {:?} instruction should not be reading an address", addressing_mode)
         }
@@ -356,7 +368,7 @@ impl CPU {
 
     fn increment_memory(&mut self, addressing_mode: &AddressingMode) {
 
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         let mut data = self.mem_read_u8(target_addr);
         
         data = data.wrapping_add(1);
@@ -367,7 +379,7 @@ impl CPU {
 
     fn decrement_memory(&mut self, addressing_mode: &AddressingMode) {
 
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         let mut data = self.mem_read_u8(target_addr);
         
         data = data.wrapping_sub(1);
@@ -379,7 +391,7 @@ impl CPU {
     /// Don't set negative and zero bits, and if the 
     fn decrement_memory_unofficial(&mut self, addressing_mode: &AddressingMode) {
 
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         let mut data = self.mem_read_u8(target_addr);
         data = data.wrapping_sub(1);
         self.mem_write_u8(target_addr, data);
@@ -391,14 +403,14 @@ impl CPU {
 
     fn increment_mem_and_subtract_from_acc(&mut self, addressing_mode: &AddressingMode) {
         self.increment_memory(addressing_mode);
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         let data = self.mem_read_u8(target_addr) as i8;
         self.add_to_acc(data.wrapping_neg().wrapping_sub(1) as u8);
     }
 
     fn inclusive_or(&mut self, addressing_mode: &AddressingMode) {
 
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         let data = self.mem_read_u8(target_addr);
 
         self.acc |= data;
@@ -408,7 +420,7 @@ impl CPU {
 
     fn exclusive_or(&mut self, addressing_mode: &AddressingMode) {
 
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         let data = self.mem_read_u8(target_addr);
 
         self.acc ^= data;
@@ -482,7 +494,7 @@ impl CPU {
     /// 6502 has a bug when the indirect vector is on a page boundary
     /// <https://www.nesdev.org/obelisk-6502-guide/reference.html#JMP>
     fn jump(&mut self, addressing_mode: &AddressingMode) {
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         self.pc = target_addr;
     }
 
@@ -494,7 +506,7 @@ impl CPU {
         // We're doing +2 (because we read 2 bytes after the instruction)
         // and -1 because we want to store the target return-1
         self.stack_push_u16(self.pc + 2 - 1);
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         self.pc = target_addr;
 
     }
@@ -507,7 +519,8 @@ impl CPU {
     // ! Really wanted to do a guardian clause instead, but tarpaulin wasn't covering the early return
     fn branch_if(&mut self, condition: bool) {
         if condition {
-            self.pc = self.get_operand_address(&AddressingMode::Relative);
+            self.bus.tick();
+            (self.pc, _) = self.get_operand_address(&AddressingMode::Relative);
         }
     }
 
@@ -529,14 +542,14 @@ impl CPU {
     }
 
     fn add_with_carry(&mut self, addressing_mode: &AddressingMode) {
-        let address = self.get_operand_address(addressing_mode);
-        let data = self.mem_read_u8(address);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
+        let data = self.mem_read_u8(target_addr);
         self.add_to_acc(data);
     }
 
     fn subtract_with_carry(&mut self, addressing_mode: &AddressingMode) {
-        let address = self.get_operand_address(addressing_mode);
-        let data = self.mem_read_u8(address) as i8;
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
+        let data = self.mem_read_u8(target_addr) as i8;
         self.add_to_acc(data.wrapping_neg().wrapping_sub(1) as u8);
     }
 
@@ -554,27 +567,27 @@ impl CPU {
 
     fn mem_shift_left(&mut self, addressing_mode: &AddressingMode) {
 
-        let address = self.get_operand_address(addressing_mode);
-        let mut data = self.mem_read_u8(address);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
+        let mut data = self.mem_read_u8(target_addr);
         
         self.conditional_flag_set(data & 0b1000_0000 > 0, CARRY_FLAG);
         data <<= 1;
 
         self.set_negative_and_zero_flags(data);
-        self.mem_write_u8(address, data);
+        self.mem_write_u8(target_addr, data);
 
     }
 
     fn mem_shift_right(&mut self, addressing_mode: &AddressingMode) {
 
-        let address = self.get_operand_address(addressing_mode);
-        let mut data = self.mem_read_u8(address);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
+        let mut data = self.mem_read_u8(target_addr);
         
         self.conditional_flag_set(data & 1 == 1, CARRY_FLAG);
         data >>= 1;
 
         self.set_negative_and_zero_flags(data);
-        self.mem_write_u8(address, data);
+        self.mem_write_u8(target_addr, data);
 
     }
 
@@ -610,7 +623,7 @@ impl CPU {
 
     fn rotate_mem_left(&mut self, addressing_mode: &AddressingMode) {
 
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         let mut data = self.mem_read_u8(target_addr);
         let carry_enabled = self.is_flag_set(CARRY_FLAG);
 
@@ -628,7 +641,7 @@ impl CPU {
 
     fn rotate_mem_right(&mut self, addressing_mode: &AddressingMode) {
 
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         let mut data = self.mem_read_u8(target_addr);
         let carry_enabled = self.is_flag_set(CARRY_FLAG);
 
@@ -661,7 +674,7 @@ impl CPU {
 
     fn rotate_right_and_add_to_acc(&mut self, addressing_mode: &AddressingMode) {
         self.rotate_mem_right(addressing_mode);
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         let data = self.mem_read_u8(target_addr);
         self.add_to_acc(data);
     }
@@ -693,10 +706,20 @@ impl CPU {
         self.conditional_flag_set(value & NEGATIVE_FLAG == NEGATIVE_FLAG, NEGATIVE_FLAG);
     }
 
+    fn page_crossed(&self, base: u16, target: u16) -> bool {
+        (base & 0xFF00) != (target & 0xFF00)
+    }
+
+    fn tick_if_page_crossed(&mut self, page_crossed: bool) {
+        if page_crossed {
+            self.bus.tick();
+        }
+    }
+
     fn load_register(&mut self, addressing_mode: &AddressingMode, target_register: &RegisterID) {
 
-        let address = self.get_operand_address(addressing_mode);
-        let data = self.mem_read_u8(address);
+        let (target_addr, page_crossed) = self.get_operand_address(addressing_mode);
+        let data = self.mem_read_u8(target_addr);
         let register_ref = match target_register {
             RegisterID::ACC => &mut self.acc,
             RegisterID::X => &mut self.x,
@@ -706,6 +729,7 @@ impl CPU {
         
         *register_ref = data;
         self.set_negative_and_zero_flags(data);
+        self.tick_if_page_crossed(page_crossed);
 
     }
 
@@ -718,8 +742,8 @@ impl CPU {
             RegisterID::SP => panic!("Stack pointer should not be a target for storing")
         };
 
-        let address = self.get_operand_address(addressing_mode);
-        self.mem_write_u8(address, register_value);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
+        self.mem_write_u8(target_addr, register_value);
 
     }
 
@@ -745,7 +769,7 @@ impl CPU {
             RegisterID::SP => panic!("Stack pointer should not be a target for storing")
         };
 
-        let target_addr = self.get_operand_address(addressing_mode);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
         self.mem_write_u8(target_addr, reg_a_value & reg_b_value);
 
     }
@@ -776,8 +800,8 @@ impl CPU {
 
     fn compare_register(&mut self, addressing_mode: &AddressingMode, target_register: &RegisterID) {
 
-        let address = self.get_operand_address(addressing_mode);
-        let data = self.mem_read_u8(address);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
+        let data = self.mem_read_u8(target_addr);
         let register_value = match target_register {
             RegisterID::ACC => self.acc,
             RegisterID::X => self.x,
@@ -791,16 +815,16 @@ impl CPU {
     }
 
     fn and(&mut self, addressing_mode: &AddressingMode) {
-        let address = self.get_operand_address(addressing_mode);
-        let data = self.mem_read_u8(address);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
+        let data = self.mem_read_u8(target_addr);
         self.acc &= data;
         self.set_negative_and_zero_flags(self.acc);
     }
 
     fn bit(&mut self, addressing_mode: &AddressingMode) {
 
-        let address = self.get_operand_address(addressing_mode);
-        let data = self.mem_read_u8(address);
+        let (target_addr, _) = self.get_operand_address(addressing_mode);
+        let data = self.mem_read_u8(target_addr);
         let result = self.acc & data;
 
         self.conditional_flag_set(data & OVERFLOW_FLAG == OVERFLOW_FLAG, OVERFLOW_FLAG);
@@ -810,7 +834,7 @@ impl CPU {
     }
 
     fn nop_read(&self, addressing_mode: &AddressingMode) {
-        let addr = self.get_operand_address(addressing_mode);
+        let (addr, _) = self.get_operand_address(addressing_mode);
         self.mem_read_u8(addr);
     }
 

--- a/src/cpu_trace.rs
+++ b/src/cpu_trace.rs
@@ -25,7 +25,7 @@ pub fn trace(cpu: &CPU) -> String {
   let (mem_addr, stored_value) = match opcode.addressing_mode {
       AddressingMode::Immediate | AddressingMode::None | AddressingMode::Implied | AddressingMode::Relative => (0, 0),
       _ => {
-          let addr = cpu.get_absolute_address(&opcode.addressing_mode, begin+1);
+          let (addr, _) = cpu.get_absolute_address(&opcode.addressing_mode, begin+1);
           (addr, cpu.mem_read_u8(addr))
       }
   };
@@ -138,8 +138,8 @@ pub fn trace(cpu: &CPU) -> String {
       .to_string();
 
   format!(
-      "{:47} A:{:02x} X:{:02x} Y:{:02x} P:{:02x} SP:{:02x}",
-      asm_str, cpu.acc, cpu.x, cpu.y, cpu.status, cpu.sp,
+      "{:47} A:{:02x} X:{:02x} Y:{:02x} P:{:02x} SP:{:02x} CYC:{}",
+      asm_str, cpu.acc, cpu.x, cpu.y, cpu.status, cpu.sp, cpu.bus.get_cycles()
   )
   .to_ascii_uppercase()
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -63,8 +63,6 @@ impl Instruction {
 lazy_static! {
 
   pub static ref CPU_INSTRUCTIONS: Vec<Instruction> = vec![
-    Instruction::new(0x00, "BRK", 1, 7, AddressingMode::Implied),
-
     Instruction::new(0x69, "ADC", 2, 2, AddressingMode::Immediate),
     Instruction::new(0x65, "ADC", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0x75, "ADC", 2, 4, AddressingMode::ZeroPageX),
@@ -101,6 +99,8 @@ lazy_static! {
     Instruction::new(0x24, "BIT", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0x2C, "BIT", 3, 4, AddressingMode::Absolute),
 
+    Instruction::new(0x00, "BRK", 1, 7, AddressingMode::Implied),
+
     Instruction::new(0x18, "CLC", 1, 2, AddressingMode::Implied),
     Instruction::new(0xD8, "CLD", 1, 2, AddressingMode::Implied),
     Instruction::new(0x58, "CLI", 1, 2, AddressingMode::Implied),
@@ -123,7 +123,6 @@ lazy_static! {
     Instruction::new(0xC4, "CPY", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0xCC, "CPY", 3, 4, AddressingMode::Absolute),
 
-    
     Instruction::new(0xC7, "*DCP", 2, 3, AddressingMode::ZeroPage), // ! Illegal
     Instruction::new(0xD7, "*DCP", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
     Instruction::new(0xCF, "*DCP", 3, 4, AddressingMode::Absolute), // ! Illegal
@@ -181,22 +180,22 @@ lazy_static! {
     Instruction::new(0xA5, "LDA", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0xB5, "LDA", 2, 4, AddressingMode::ZeroPageX),
     Instruction::new(0xAD, "LDA", 3, 4, AddressingMode::Absolute),
-    Instruction::new(0xBD, "LDA", 3, 4, AddressingMode::AbsoluteX), // TODO: +1 cpu cycle if page is crossed
-    Instruction::new(0xB9, "LDA", 3, 4, AddressingMode::AbsoluteY), // TODO: +1 cpu cycle if page is crossed
+    Instruction::new(0xBD, "LDA", 3, 4, AddressingMode::AbsoluteX),
+    Instruction::new(0xB9, "LDA", 3, 4, AddressingMode::AbsoluteY),
     Instruction::new(0xA1, "LDA", 2, 6, AddressingMode::IndirectX),
-    Instruction::new(0xB1, "LDA", 2, 5, AddressingMode::IndirectY), // TODO: +1 cpu cycle if page is crossed
+    Instruction::new(0xB1, "LDA", 2, 5, AddressingMode::IndirectY),
 
     Instruction::new(0xA2, "LDX", 2, 2, AddressingMode::Immediate),
     Instruction::new(0xA6, "LDX", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0xB6, "LDX", 2, 4, AddressingMode::ZeroPageY),
     Instruction::new(0xAE, "LDX", 3, 4, AddressingMode::Absolute),
-    Instruction::new(0xBE, "LDX", 3, 4, AddressingMode::AbsoluteY), // TODO: +1 cpu cycle if page is crossed
+    Instruction::new(0xBE, "LDX", 3, 4, AddressingMode::AbsoluteY),
 
     Instruction::new(0xA0, "LDY", 2, 2, AddressingMode::Immediate),
     Instruction::new(0xA4, "LDY", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0xB4, "LDY", 2, 4, AddressingMode::ZeroPageX),
     Instruction::new(0xAC, "LDY", 3, 4, AddressingMode::Absolute),
-    Instruction::new(0xBC, "LDY", 3, 4, AddressingMode::AbsoluteX), // TODO: +1 cpu cycle if page is crossed
+    Instruction::new(0xBC, "LDY", 3, 4, AddressingMode::AbsoluteX),
 
     Instruction::new(0x4A, "LSR", 1, 2, AddressingMode::None),
     Instruction::new(0x46, "LSR", 2, 5, AddressingMode::ZeroPage),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -247,6 +247,14 @@ lazy_static! {
     Instruction::new(0x68, "PLA", 1, 4, AddressingMode::Implied),
     Instruction::new(0x28, "PLP", 1, 4, AddressingMode::Implied),
 
+    Instruction::new(0x27, "*RLA", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x37, "*RLA", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x2F, "*RLA", 3, 4, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x3F, "*RLA", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0x3B, "*RLA", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0x23, "*RLA", 2, 6, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0x33, "*RLA", 2, 5, AddressingMode::IndirectY), // ! Illegal
+
     Instruction::new(0x2A, "ROL", 1, 2, AddressingMode::None),
     Instruction::new(0x26, "ROL", 2, 5, AddressingMode::ZeroPage),
     Instruction::new(0x36, "ROL", 2, 6, AddressingMode::ZeroPageX),
@@ -258,6 +266,14 @@ lazy_static! {
     Instruction::new(0x76, "ROR", 2, 6, AddressingMode::ZeroPageX),
     Instruction::new(0x6E, "ROR", 3, 6, AddressingMode::Absolute),
     Instruction::new(0x7E, "ROR", 3, 7, AddressingMode::AbsoluteX),
+
+    Instruction::new(0x67, "*RRA", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x77, "*RRA", 2, 3, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x6F, "*RRA", 3, 4, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x7F, "*RRA", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0x7B, "*RRA", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0x63, "*RRA", 2, 6, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0x73, "*RRA", 2, 5, AddressingMode::IndirectY), // ! Illegal
 
     Instruction::new(0x40, "RTI", 1, 6, AddressingMode::Implied),
 
@@ -290,6 +306,14 @@ lazy_static! {
     Instruction::new(0x1B, "*SLO", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
     Instruction::new(0x03, "*SLO", 2, 6, AddressingMode::IndirectX), // ! Illegal
     Instruction::new(0x13, "*SLO", 2, 5, AddressingMode::IndirectY), // ! Illegal
+
+    Instruction::new(0x47, "*SRE", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x57, "*SRE", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x4F, "*SRE", 3, 4, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x5F, "*SRE", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0x5B, "*SRE", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0x43, "*SRE", 2, 6, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0x53, "*SRE", 2, 5, AddressingMode::IndirectY), // ! Illegal
 
     Instruction::new(0x85, "STA", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0x95, "STA", 2, 4, AddressingMode::ZeroPageX),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -181,6 +181,33 @@ lazy_static! {
     Instruction::new(0x5E, "LSR", 3, 7, AddressingMode::AbsoluteX),
 
     Instruction::new(0xEA, "NOP", 1, 2, AddressingMode::Implied),
+    
+    Instruction::new(0x1A, "*NOP", 1, 2, AddressingMode::Implied),
+    Instruction::new(0x3A, "*NOP", 1, 2, AddressingMode::Implied),
+    Instruction::new(0x5A, "*NOP", 1, 2, AddressingMode::Implied),
+    Instruction::new(0x7A, "*NOP", 1, 2, AddressingMode::Implied),
+    Instruction::new(0xDA, "*NOP", 1, 2, AddressingMode::Implied),
+    Instruction::new(0xFA, "*NOP", 1, 2, AddressingMode::Implied),
+
+    Instruction::new(0x04, "*NOP", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x44, "*NOP", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x64, "*NOP", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x14, "*NOP", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x34, "*NOP", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x54, "*NOP", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x74, "*NOP", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0xD4, "*NOP", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0xF4, "*NOP", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    
+    Instruction::new(0x0C, "*NOP", 3, 4, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x1C, "*NOP", 3, 4, AddressingMode::AbsoluteX), // ! Illegal // TODO: +1 cpu cycle if page is crossed
+    Instruction::new(0x3C, "*NOP", 3, 4, AddressingMode::AbsoluteX), // ! Illegal // TODO: +1 cpu cycle if page is crossed
+    Instruction::new(0x5C, "*NOP", 3, 4, AddressingMode::AbsoluteX), // ! Illegal // TODO: +1 cpu cycle if page is crossed
+    Instruction::new(0x7C, "*NOP", 3, 4, AddressingMode::AbsoluteX), // ! Illegal // TODO: +1 cpu cycle if page is crossed
+    Instruction::new(0xDC, "*NOP", 3, 4, AddressingMode::AbsoluteX), // ! Illegal // TODO: +1 cpu cycle if page is crossed
+    Instruction::new(0xFC, "*NOP", 3, 4, AddressingMode::AbsoluteX), // ! Illegal // TODO: +1 cpu cycle if page is crossed
+
+    Instruction::new(0x80, "*NOP", 2, 2, AddressingMode::Immediate), // ! Illegal
 
     Instruction::new(0x09, "ORA", 2, 2, AddressingMode::Immediate),
     Instruction::new(0x05, "ORA", 2, 3, AddressingMode::ZeroPage),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -123,6 +123,15 @@ lazy_static! {
     Instruction::new(0xC4, "CPY", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0xCC, "CPY", 3, 4, AddressingMode::Absolute),
 
+    
+    Instruction::new(0xC7, "*DCP", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0xD7, "*DCP", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0xCF, "*DCP", 3, 4, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0xDF, "*DCP", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0xDB, "*DCP", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0xC3, "*DCP", 2, 6, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0xD3, "*DCP", 2, 5, AddressingMode::IndirectY), // ! Illegal
+
     Instruction::new(0xC6, "DEC", 2, 5, AddressingMode::ZeroPage),
     Instruction::new(0xD6, "DEC", 2, 6, AddressingMode::ZeroPageX),
     Instruction::new(0xCE, "DEC", 3, 6, AddressingMode::Absolute),
@@ -153,11 +162,11 @@ lazy_static! {
 
     Instruction::new(0x20, "JSR", 3, 6, AddressingMode::Absolute),
 
-    Instruction::new(0xA3, "*LAX", 2, 6, AddressingMode::IndirectX), // ! Illegal
     Instruction::new(0xA7, "*LAX", 2, 3, AddressingMode::ZeroPage), // ! Illegal
     Instruction::new(0xB7, "*LAX", 2, 4, AddressingMode::ZeroPageY), // ! Illegal
     Instruction::new(0xAF, "*LAX", 3, 4, AddressingMode::Absolute), // ! Illegal
     Instruction::new(0xBF, "*LAX", 3, 5, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0xA3, "*LAX", 2, 6, AddressingMode::IndirectX), // ! Illegal
     Instruction::new(0xB3, "*LAX", 2, 5, AddressingMode::IndirectY), // ! Illegal
 
     Instruction::new(0xA9, "LDA", 2, 2, AddressingMode::Immediate),
@@ -246,6 +255,11 @@ lazy_static! {
 
     Instruction::new(0x60, "RTS", 1, 6, AddressingMode::Implied),
 
+    Instruction::new(0x87, "*SAX", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x97, "*SAX", 2, 4, AddressingMode::ZeroPageY), // ! Illegal
+    Instruction::new(0x8F, "*SAX", 3, 4, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x83, "*SAX", 2, 6, AddressingMode::IndirectX), // ! Illegal
+
     Instruction::new(0xE9, "SBC", 2, 2, AddressingMode::Immediate),
     Instruction::new(0xE5, "SBC", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0xF5, "SBC", 2, 4, AddressingMode::ZeroPageX),
@@ -254,6 +268,8 @@ lazy_static! {
     Instruction::new(0xF9, "SBC", 3, 4, AddressingMode::AbsoluteY), // TODO: +1 cpu cycle if page is crossed
     Instruction::new(0xE1, "SBC", 2, 6, AddressingMode::IndirectX),
     Instruction::new(0xF1, "SBC", 2, 5, AddressingMode::IndirectY), // TODO: +1 cpu cycle if page is crossed
+
+    Instruction::new(0xEB, "*SBC", 2, 2, AddressingMode::Immediate), // ! Illegal
 
     Instruction::new(0x38, "SEC", 1, 2, AddressingMode::Implied),
     Instruction::new(0xF8, "SED", 1, 2, AddressingMode::Implied),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -153,6 +153,13 @@ lazy_static! {
 
     Instruction::new(0x20, "JSR", 3, 6, AddressingMode::Absolute),
 
+    Instruction::new(0xA3, "*LAX", 2, 6, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0xA7, "*LAX", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0xB7, "*LAX", 2, 4, AddressingMode::ZeroPageY), // ! Illegal
+    Instruction::new(0xAF, "*LAX", 3, 4, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0xBF, "*LAX", 3, 5, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0xB3, "*LAX", 2, 5, AddressingMode::IndirectY), // ! Illegal
+
     Instruction::new(0xA9, "LDA", 2, 2, AddressingMode::Immediate),
     Instruction::new(0xA5, "LDA", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0xB5, "LDA", 2, 4, AddressingMode::ZeroPageX),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -123,13 +123,13 @@ lazy_static! {
     Instruction::new(0xC4, "CPY", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0xCC, "CPY", 3, 4, AddressingMode::Absolute),
 
-    Instruction::new(0xC7, "*DCP", 2, 3, AddressingMode::ZeroPage), // ! Illegal
-    Instruction::new(0xD7, "*DCP", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
-    Instruction::new(0xCF, "*DCP", 3, 4, AddressingMode::Absolute), // ! Illegal
-    Instruction::new(0xDF, "*DCP", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
-    Instruction::new(0xDB, "*DCP", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
-    Instruction::new(0xC3, "*DCP", 2, 6, AddressingMode::IndirectX), // ! Illegal
-    Instruction::new(0xD3, "*DCP", 2, 5, AddressingMode::IndirectY), // ! Illegal
+    Instruction::new(0xC7, "*DCP", 2, 5, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0xD7, "*DCP", 2, 6, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0xCF, "*DCP", 3, 6, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0xDF, "*DCP", 3, 7, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0xDB, "*DCP", 3, 7, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0xC3, "*DCP", 2, 8, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0xD3, "*DCP", 2, 8, AddressingMode::IndirectY), // ! Illegal
 
     Instruction::new(0xC6, "DEC", 2, 5, AddressingMode::ZeroPage),
     Instruction::new(0xD6, "DEC", 2, 6, AddressingMode::ZeroPageX),
@@ -156,13 +156,13 @@ lazy_static! {
     Instruction::new(0xE8, "INX", 1, 2, AddressingMode::Implied),
     Instruction::new(0xC8, "INY", 1, 2, AddressingMode::Implied),
 
-    Instruction::new(0xE7, "*ISB", 2, 3, AddressingMode::ZeroPage), // ! Illegal
-    Instruction::new(0xF7, "*ISB", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
-    Instruction::new(0xEF, "*ISB", 3, 4, AddressingMode::Absolute), // ! Illegal
-    Instruction::new(0xFF, "*ISB", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
-    Instruction::new(0xFB, "*ISB", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
-    Instruction::new(0xE3, "*ISB", 2, 6, AddressingMode::IndirectX), // ! Illegal
-    Instruction::new(0xF3, "*ISB", 2, 5, AddressingMode::IndirectY), // ! Illegal
+    Instruction::new(0xE7, "*ISB", 2, 5, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0xF7, "*ISB", 2, 6, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0xEF, "*ISB", 3, 6, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0xFF, "*ISB", 3, 7, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0xFB, "*ISB", 3, 7, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0xE3, "*ISB", 2, 8, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0xF3, "*ISB", 2, 8, AddressingMode::IndirectY), // ! Illegal
 
     Instruction::new(0x4C, "JMP", 3, 3, AddressingMode::Absolute),
     Instruction::new(0x6C, "JMP", 3, 5, AddressingMode::Indirect),
@@ -172,7 +172,7 @@ lazy_static! {
     Instruction::new(0xA7, "*LAX", 2, 3, AddressingMode::ZeroPage), // ! Illegal
     Instruction::new(0xB7, "*LAX", 2, 4, AddressingMode::ZeroPageY), // ! Illegal
     Instruction::new(0xAF, "*LAX", 3, 4, AddressingMode::Absolute), // ! Illegal
-    Instruction::new(0xBF, "*LAX", 3, 5, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0xBF, "*LAX", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
     Instruction::new(0xA3, "*LAX", 2, 6, AddressingMode::IndirectX), // ! Illegal
     Instruction::new(0xB3, "*LAX", 2, 5, AddressingMode::IndirectY), // ! Illegal
 
@@ -246,13 +246,13 @@ lazy_static! {
     Instruction::new(0x68, "PLA", 1, 4, AddressingMode::Implied),
     Instruction::new(0x28, "PLP", 1, 4, AddressingMode::Implied),
 
-    Instruction::new(0x27, "*RLA", 2, 3, AddressingMode::ZeroPage), // ! Illegal
-    Instruction::new(0x37, "*RLA", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
-    Instruction::new(0x2F, "*RLA", 3, 4, AddressingMode::Absolute), // ! Illegal
-    Instruction::new(0x3F, "*RLA", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
-    Instruction::new(0x3B, "*RLA", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
-    Instruction::new(0x23, "*RLA", 2, 6, AddressingMode::IndirectX), // ! Illegal
-    Instruction::new(0x33, "*RLA", 2, 5, AddressingMode::IndirectY), // ! Illegal
+    Instruction::new(0x27, "*RLA", 2, 5, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x37, "*RLA", 2, 6, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x2F, "*RLA", 3, 6, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x3F, "*RLA", 3, 7, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0x3B, "*RLA", 3, 7, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0x23, "*RLA", 2, 8, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0x33, "*RLA", 2, 8, AddressingMode::IndirectY), // ! Illegal
 
     Instruction::new(0x2A, "ROL", 1, 2, AddressingMode::None),
     Instruction::new(0x26, "ROL", 2, 5, AddressingMode::ZeroPage),
@@ -266,13 +266,13 @@ lazy_static! {
     Instruction::new(0x6E, "ROR", 3, 6, AddressingMode::Absolute),
     Instruction::new(0x7E, "ROR", 3, 7, AddressingMode::AbsoluteX),
 
-    Instruction::new(0x67, "*RRA", 2, 3, AddressingMode::ZeroPage), // ! Illegal
-    Instruction::new(0x77, "*RRA", 2, 3, AddressingMode::ZeroPageX), // ! Illegal
-    Instruction::new(0x6F, "*RRA", 3, 4, AddressingMode::Absolute), // ! Illegal
-    Instruction::new(0x7F, "*RRA", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
-    Instruction::new(0x7B, "*RRA", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
-    Instruction::new(0x63, "*RRA", 2, 6, AddressingMode::IndirectX), // ! Illegal
-    Instruction::new(0x73, "*RRA", 2, 5, AddressingMode::IndirectY), // ! Illegal
+    Instruction::new(0x67, "*RRA", 2, 5, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x77, "*RRA", 2, 6, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x6F, "*RRA", 3, 6, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x7F, "*RRA", 3, 7, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0x7B, "*RRA", 3, 7, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0x63, "*RRA", 2, 8, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0x73, "*RRA", 2, 8, AddressingMode::IndirectY), // ! Illegal
 
     Instruction::new(0x40, "RTI", 1, 6, AddressingMode::Implied),
 
@@ -298,21 +298,21 @@ lazy_static! {
     Instruction::new(0xF8, "SED", 1, 2, AddressingMode::Implied),
     Instruction::new(0x78, "SEI", 1, 2, AddressingMode::Implied),
 
-    Instruction::new(0x07, "*SLO", 2, 3, AddressingMode::ZeroPage), // ! Illegal
-    Instruction::new(0x17, "*SLO", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
-    Instruction::new(0x0F, "*SLO", 3, 4, AddressingMode::Absolute), // ! Illegal
-    Instruction::new(0x1F, "*SLO", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
-    Instruction::new(0x1B, "*SLO", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
-    Instruction::new(0x03, "*SLO", 2, 6, AddressingMode::IndirectX), // ! Illegal
-    Instruction::new(0x13, "*SLO", 2, 5, AddressingMode::IndirectY), // ! Illegal
+    Instruction::new(0x07, "*SLO", 2, 5, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x17, "*SLO", 2, 6, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x0F, "*SLO", 3, 6, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x1F, "*SLO", 3, 7, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0x1B, "*SLO", 3, 7, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0x03, "*SLO", 2, 8, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0x13, "*SLO", 2, 8, AddressingMode::IndirectY), // ! Illegal
 
-    Instruction::new(0x47, "*SRE", 2, 3, AddressingMode::ZeroPage), // ! Illegal
-    Instruction::new(0x57, "*SRE", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
-    Instruction::new(0x4F, "*SRE", 3, 4, AddressingMode::Absolute), // ! Illegal
-    Instruction::new(0x5F, "*SRE", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
-    Instruction::new(0x5B, "*SRE", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
-    Instruction::new(0x43, "*SRE", 2, 6, AddressingMode::IndirectX), // ! Illegal
-    Instruction::new(0x53, "*SRE", 2, 5, AddressingMode::IndirectY), // ! Illegal
+    Instruction::new(0x47, "*SRE", 2, 5, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x57, "*SRE", 2, 6, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x4F, "*SRE", 3, 6, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x5F, "*SRE", 3, 7, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0x5B, "*SRE", 3, 7, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0x43, "*SRE", 2, 8, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0x53, "*SRE", 2, 8, AddressingMode::IndirectY), // ! Illegal
 
     Instruction::new(0x85, "STA", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0x95, "STA", 2, 4, AddressingMode::ZeroPageX),

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -157,6 +157,14 @@ lazy_static! {
     Instruction::new(0xE8, "INX", 1, 2, AddressingMode::Implied),
     Instruction::new(0xC8, "INY", 1, 2, AddressingMode::Implied),
 
+    Instruction::new(0xE7, "*ISB", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0xF7, "*ISB", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0xEF, "*ISB", 3, 4, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0xFF, "*ISB", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0xFB, "*ISB", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0xE3, "*ISB", 2, 6, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0xF3, "*ISB", 2, 5, AddressingMode::IndirectY), // ! Illegal
+
     Instruction::new(0x4C, "JMP", 3, 3, AddressingMode::Absolute),
     Instruction::new(0x6C, "JMP", 3, 5, AddressingMode::Indirect),
 
@@ -274,6 +282,14 @@ lazy_static! {
     Instruction::new(0x38, "SEC", 1, 2, AddressingMode::Implied),
     Instruction::new(0xF8, "SED", 1, 2, AddressingMode::Implied),
     Instruction::new(0x78, "SEI", 1, 2, AddressingMode::Implied),
+
+    Instruction::new(0x07, "*SLO", 2, 3, AddressingMode::ZeroPage), // ! Illegal
+    Instruction::new(0x17, "*SLO", 2, 4, AddressingMode::ZeroPageX), // ! Illegal
+    Instruction::new(0x0F, "*SLO", 3, 4, AddressingMode::Absolute), // ! Illegal
+    Instruction::new(0x1F, "*SLO", 3, 4, AddressingMode::AbsoluteX), // ! Illegal
+    Instruction::new(0x1B, "*SLO", 3, 4, AddressingMode::AbsoluteY), // ! Illegal
+    Instruction::new(0x03, "*SLO", 2, 6, AddressingMode::IndirectX), // ! Illegal
+    Instruction::new(0x13, "*SLO", 2, 5, AddressingMode::IndirectY), // ! Illegal
 
     Instruction::new(0x85, "STA", 2, 3, AddressingMode::ZeroPage),
     Instruction::new(0x95, "STA", 2, 4, AddressingMode::ZeroPageX),


### PR DESCRIPTION
(Attempting to) make the CPU cycle-accurate.
The NES is a distributed system, the CPU and PPU run at their own rates. So if we want to be able to run these components in sync, we need to have the CPU be cycle-accurate to actual hardware so we can base the PPU timings off of it