### PR TITLE
Refactor status with bitflags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitflags = "2.4.0"
 clap = { version = "4.4.0", features = ["derive"] }
 lazy_static = "*"
 log = "0.4.20"

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -7,8 +7,8 @@ bitflags! {
 
     /// Aliases for the flags in the 6502 status register.
     /// More information on these flags can be found here: <https://www.nesdev.org/wiki/Status_flags>
-    #[derive(Clone, Copy)]
-    pub struct StatusRegister: u8 {
+    #[derive(Clone, Copy, Debug)]
+    pub struct CPUFlags: u8 {
         const CARRY =              0b0000_0001;
         const ZERO =               0b0000_0010;
         const INTERRUPT_DISABLE =  0b0000_0100;
@@ -66,7 +66,7 @@ pub struct CPU {
     pub acc: u8,
     pub x: u8,
     pub y: u8,
-    pub status: StatusRegister,
+    pub status: CPUFlags,
     pub bus: Bus,
 
 }
@@ -124,7 +124,7 @@ impl CPU {
             acc: 0,
             x: 0,
             y: 0,
-            status: StatusRegister::from_bits_truncate(0x24), // Break flags
+            status: CPUFlags::from_bits_truncate(0x24), // Break flags
             bus
         }
     }
@@ -136,7 +136,7 @@ impl CPU {
         self.acc = 0;
         self.x = 0;
         self.y = 0;
-        self.status = StatusRegister::from_bits_truncate(0);
+        self.status = CPUFlags::from_bits_truncate(0);
     }
 
     /// DEPRECATED?? Maybe only useful for testing??
@@ -145,7 +145,7 @@ impl CPU {
     /// while in a custom state, do not call this and instead set the state, call load(), then run()
     pub fn load_and_run(&mut self, program: Vec<u8>) {
         self.load(program);
-        self.reset();
+        // self.reset();
         self.run();
     }
 
@@ -157,7 +157,7 @@ impl CPU {
         for (index, byte) in program.iter().enumerate() {
             self.mem_write_u8(start_vector+index as u16, *byte);
         }
-        self.mem_write_u16(0xFFFC, start_vector);
+        self.pc = 0x0600;
     }
 
     /// DEPRECATED?? Maybe only useful for testing??
@@ -221,13 +221,13 @@ impl CPU {
                 0x8A => self.transfer_register(&RegisterID::X, &RegisterID::ACC),
                 0x9A => self.transfer_register(&RegisterID::X, &RegisterID::SP),
                 0x98 => self.transfer_register(&RegisterID::Y, &RegisterID::ACC),
-                0x18 => self.clear_flag(StatusRegister::CARRY),
-                0xD8 => self.clear_flag(StatusRegister::DECIMAL_MODE),
-                0x58 => self.clear_flag(StatusRegister::INTERRUPT_DISABLE),
-                0xB8 => self.clear_flag(StatusRegister::OVERFLOW),
-                0x38 => self.set_flag(StatusRegister::CARRY),
-                0xF8 => self.set_flag(StatusRegister::DECIMAL_MODE),
-                0x78 => self.set_flag(StatusRegister::INTERRUPT_DISABLE),
+                0x18 => self.clear_flag(CPUFlags::CARRY),
+                0xD8 => self.clear_flag(CPUFlags::DECIMAL_MODE),
+                0x58 => self.clear_flag(CPUFlags::INTERRUPT_DISABLE),
+                0xB8 => self.clear_flag(CPUFlags::OVERFLOW),
+                0x38 => self.set_flag(CPUFlags::CARRY),
+                0xF8 => self.set_flag(CPUFlags::DECIMAL_MODE),
+                0x78 => self.set_flag(CPUFlags::INTERRUPT_DISABLE),
                 0xCA => self.decrement_register(&RegisterID::X),
                 0x88 => self.decrement_register(&RegisterID::Y),
                 0xE8 => self.increment_register(&RegisterID::X),
@@ -248,14 +248,14 @@ impl CPU {
                 0x46 | 0x56 | 0x4E | 0x5E => self.mem_shift_right(&ins.addressing_mode),
                 0x26 | 0x36 | 0x2E | 0x3E => self.rotate_mem_left(&ins.addressing_mode),
                 0x66 | 0x76 | 0x6E | 0x7E => self.rotate_mem_right(&ins.addressing_mode),
-                0xB0 => self.branch_if(self.is_flag_set(StatusRegister::CARRY)),
-                0xF0 => self.branch_if(self.is_flag_set(StatusRegister::ZERO)),
-                0x30 => self.branch_if(self.is_flag_set(StatusRegister::NEGATIVE)),
-                0x70 => self.branch_if(self.is_flag_set(StatusRegister::OVERFLOW)),
-                0x90 => self.branch_if(!self.is_flag_set(StatusRegister::CARRY)),
-                0xD0 => self.branch_if(!self.is_flag_set(StatusRegister::ZERO)),
-                0x10 => self.branch_if(!self.is_flag_set(StatusRegister::NEGATIVE)),
-                0x50 => self.branch_if(!self.is_flag_set(StatusRegister::OVERFLOW)),
+                0xB0 => self.branch_if(self.is_flag_set(CPUFlags::CARRY)),
+                0xF0 => self.branch_if(self.is_flag_set(CPUFlags::ZERO)),
+                0x30 => self.branch_if(self.is_flag_set(CPUFlags::NEGATIVE)),
+                0x70 => self.branch_if(self.is_flag_set(CPUFlags::OVERFLOW)),
+                0x90 => self.branch_if(!self.is_flag_set(CPUFlags::CARRY)),
+                0xD0 => self.branch_if(!self.is_flag_set(CPUFlags::ZERO)),
+                0x10 => self.branch_if(!self.is_flag_set(CPUFlags::NEGATIVE)),
+                0x50 => self.branch_if(!self.is_flag_set(CPUFlags::OVERFLOW)),
                 0x4C | 0x6C => self.jump(&ins.addressing_mode),
                 0x20 => self.jump_to_subroutine(&ins.addressing_mode),
                 0x60 => self.return_from_subroutine(),
@@ -403,7 +403,7 @@ impl CPU {
         data = data.wrapping_sub(1);
         self.mem_write_u8(target_addr, data);
 
-        self.conditional_flag_set(data <= self.acc, StatusRegister::CARRY);
+        self.conditional_flag_set(data <= self.acc, CPUFlags::CARRY);
         self.set_negative_and_zero_flags(self.acc.wrapping_sub(data));
 
     }
@@ -478,8 +478,8 @@ impl CPU {
     /// <http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior>
     fn stack_push_status(&mut self) {
         let mut status = self.status;
-        status.insert(StatusRegister::BREAK_COMMAND_4);
-        status.insert(StatusRegister::BREAK_COMMAND_5);
+        status.insert(CPUFlags::BREAK_COMMAND_4);
+        status.insert(CPUFlags::BREAK_COMMAND_5);
         self.stack_push_u8(status.bits());
     }
 
@@ -487,15 +487,15 @@ impl CPU {
     /// strange bits 4-5 in the status. More info at the link below
     /// <http://wiki.nesdev.com/w/index.php/CPU_status_flag_behavior>
     fn stack_pop_status(&mut self) {
-        self.status = StatusRegister::from_bits_truncate(self.stack_pop_u8());
-        self.clear_flag(StatusRegister::BREAK_COMMAND_4);
-        self.set_flag(StatusRegister::BREAK_COMMAND_5);
+        self.status = CPUFlags::from_bits_truncate(self.stack_pop_u8());
+        self.clear_flag(CPUFlags::BREAK_COMMAND_4);
+        self.set_flag(CPUFlags::BREAK_COMMAND_5);
     }
 
     fn return_from_interrupt(&mut self) {
-        self.status = StatusRegister::from_bits_truncate(self.stack_pop_u8());
+        self.status = CPUFlags::from_bits_truncate(self.stack_pop_u8());
         self.pc = self.stack_pop_u16();
-        self.set_flag(StatusRegister::BREAK_COMMAND_5);
+        self.set_flag(CPUFlags::BREAK_COMMAND_5);
     }
 
     /// 6502 has a bug when the indirect vector is on a page boundary
@@ -536,15 +536,15 @@ impl CPU {
     fn add_to_acc(&mut self, data: u8) {
         let mut sum = self.acc as u16 + data as u16;
 
-        if self.is_flag_set(StatusRegister::CARRY) {
+        if self.is_flag_set(CPUFlags::CARRY) {
             sum += 1;
         }
 
         let carry = sum > 0xff;
         let has_overflow = (data ^ sum as u8) & (sum as u8 ^ self.acc) & 0x80 != 0;
 
-        self.conditional_flag_set(carry, StatusRegister::CARRY);
-        self.conditional_flag_set(has_overflow, StatusRegister::OVERFLOW);
+        self.conditional_flag_set(carry, CPUFlags::CARRY);
+        self.conditional_flag_set(has_overflow, CPUFlags::OVERFLOW);
 
         self.acc = sum as u8;
         self.set_negative_and_zero_flags(self.acc);
@@ -563,13 +563,13 @@ impl CPU {
     }
 
     fn acc_shift_left(&mut self) {
-        self.conditional_flag_set(self.acc & 0b1000_0000 > 0, StatusRegister::CARRY);
+        self.conditional_flag_set(self.acc & 0b1000_0000 > 0, CPUFlags::CARRY);
         self.acc <<= 1;
         self.set_negative_and_zero_flags(self.acc);
     }
 
     fn acc_shift_right(&mut self) {
-        self.conditional_flag_set(self.acc & 1 == 1, StatusRegister::CARRY);
+        self.conditional_flag_set(self.acc & 1 == 1, CPUFlags::CARRY);
         self.acc >>= 1;
         self.set_negative_and_zero_flags(self.acc);
     }
@@ -579,7 +579,7 @@ impl CPU {
         let (target_addr, _) = self.get_operand_address(addressing_mode);
         let mut data = self.mem_read_u8(target_addr);
         
-        self.conditional_flag_set(data & 0b1000_0000 > 0, StatusRegister::CARRY);
+        self.conditional_flag_set(data & 0b1000_0000 > 0, CPUFlags::CARRY);
         data <<= 1;
 
         self.set_negative_and_zero_flags(data);
@@ -592,7 +592,7 @@ impl CPU {
         let (target_addr, _) = self.get_operand_address(addressing_mode);
         let mut data = self.mem_read_u8(target_addr);
         
-        self.conditional_flag_set(data & 1 == 1, StatusRegister::CARRY);
+        self.conditional_flag_set(data & 1 == 1, CPUFlags::CARRY);
         data >>= 1;
 
         self.set_negative_and_zero_flags(data);
@@ -602,8 +602,8 @@ impl CPU {
 
     fn rotate_acc_left(&mut self) {
 
-        let carry_enabled = self.is_flag_set(StatusRegister::CARRY);
-        self.conditional_flag_set(self.acc >> 7 == 1, StatusRegister::CARRY);
+        let carry_enabled = self.is_flag_set(CPUFlags::CARRY);
+        self.conditional_flag_set(self.acc >> 7 == 1, CPUFlags::CARRY);
 
         self.acc <<= 1;
 
@@ -617,8 +617,8 @@ impl CPU {
 
     fn rotate_acc_right(&mut self) {
 
-        let carry_enabled = self.is_flag_set(StatusRegister::CARRY);
-        self.conditional_flag_set(self.acc & 1 == 1, StatusRegister::CARRY);
+        let carry_enabled = self.is_flag_set(CPUFlags::CARRY);
+        self.conditional_flag_set(self.acc & 1 == 1, CPUFlags::CARRY);
 
         self.acc >>= 1;
 
@@ -634,9 +634,9 @@ impl CPU {
 
         let (target_addr, _) = self.get_operand_address(addressing_mode);
         let mut data = self.mem_read_u8(target_addr);
-        let carry_enabled = self.is_flag_set(StatusRegister::CARRY);
+        let carry_enabled = self.is_flag_set(CPUFlags::CARRY);
 
-        self.conditional_flag_set(data >> 7 == 1, StatusRegister::CARRY);
+        self.conditional_flag_set(data >> 7 == 1, CPUFlags::CARRY);
         data <<= 1;
 
         if carry_enabled {
@@ -652,9 +652,9 @@ impl CPU {
 
         let (target_addr, _) = self.get_operand_address(addressing_mode);
         let mut data = self.mem_read_u8(target_addr);
-        let carry_enabled = self.is_flag_set(StatusRegister::CARRY);
+        let carry_enabled = self.is_flag_set(CPUFlags::CARRY);
 
-        self.conditional_flag_set(data & 1 == 1, StatusRegister::CARRY);
+        self.conditional_flag_set(data & 1 == 1, CPUFlags::CARRY);
         data >>= 1;
 
         if carry_enabled {
@@ -688,17 +688,17 @@ impl CPU {
         self.add_to_acc(data);
     }
 
-    fn set_flag(&mut self, flag_alias: StatusRegister) {
+    fn set_flag(&mut self, flag_alias: CPUFlags) {
         self.status.insert(flag_alias);
     }
 
-    fn clear_flag(&mut self, flag_alias: StatusRegister) {
+    fn clear_flag(&mut self, flag_alias: CPUFlags) {
         self.status.remove(flag_alias);
     }
 
     /// If `condition` is true, the specified flag is set.
     /// If `condition` is false, the specified flag is cleared.
-    fn conditional_flag_set(&mut self, condition: bool, flag_alias: StatusRegister) {
+    fn conditional_flag_set(&mut self, condition: bool, flag_alias: CPUFlags) {
         if condition {
             self.status.insert(flag_alias);
         } else {
@@ -706,13 +706,13 @@ impl CPU {
         }
     }
 
-    fn is_flag_set(&self, flag_alias: StatusRegister) -> bool {
+    fn is_flag_set(&self, flag_alias: CPUFlags) -> bool {
         self.status.contains(flag_alias)
     }
 
     fn set_negative_and_zero_flags(&mut self, value: u8) {
-        self.conditional_flag_set(value == 0, StatusRegister::ZERO);
-        self.conditional_flag_set(value & StatusRegister::NEGATIVE.bits() > 0, StatusRegister::NEGATIVE);
+        self.conditional_flag_set(value == 0, CPUFlags::ZERO);
+        self.conditional_flag_set(value & CPUFlags::NEGATIVE.bits() > 0, CPUFlags::NEGATIVE);
     }
 
     fn page_crossed(&self, base: u16, target: u16) -> bool {
@@ -826,7 +826,7 @@ impl CPU {
 
         let result = register_value.wrapping_sub(data);
         self.set_negative_and_zero_flags(result);
-        self.conditional_flag_set(register_value >= data, StatusRegister::CARRY);
+        self.conditional_flag_set(register_value >= data, CPUFlags::CARRY);
     }
 
     fn and(&mut self, addressing_mode: &AddressingMode) {
@@ -842,9 +842,9 @@ impl CPU {
         let data = self.mem_read_u8(target_addr);
         let result = self.acc & data;
 
-        self.conditional_flag_set(data & StatusRegister::OVERFLOW.bits() > 0, StatusRegister::OVERFLOW);
-        self.conditional_flag_set(data & StatusRegister::NEGATIVE.bits() > 0, StatusRegister::NEGATIVE);
-        self.conditional_flag_set(result == 0, StatusRegister::ZERO);
+        self.conditional_flag_set(data & CPUFlags::OVERFLOW.bits() > 0, CPUFlags::OVERFLOW);
+        self.conditional_flag_set(data & CPUFlags::NEGATIVE.bits() > 0, CPUFlags::NEGATIVE);
+        self.conditional_flag_set(result == 0, CPUFlags::ZERO);
 
     }
 
@@ -892,7 +892,7 @@ mod tests {
         cpu.pc = 1892;
         cpu.x = 15;
         cpu.y = 16;
-        cpu.status = StatusRegister::from_bits_truncate(0b10010000);
+        cpu.status = CPUFlags::from_bits_truncate(0b10010000);
 
         cpu.reset();
 
@@ -911,16 +911,16 @@ mod tests {
         let mut cpu = init_test_cpu();
 
         cpu.set_negative_and_zero_flags(cpu.acc);
-        assert!(cpu.is_flag_set(StatusRegister::ZERO));
+        assert!(cpu.is_flag_set(CPUFlags::ZERO));
 
         cpu.acc = 130;
         cpu.set_negative_and_zero_flags(cpu.acc);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
         cpu.acc = 16;
         cpu.set_negative_and_zero_flags(cpu.acc);
-        assert!(!cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(!cpu.is_flag_set(StatusRegister::ZERO));
+        assert!(!cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(!cpu.is_flag_set(CPUFlags::ZERO));
 
     }
 
@@ -1000,10 +1000,10 @@ mod tests {
     fn test_clear_flag() {
 
         let mut cpu = init_test_cpu();
-        cpu.status = StatusRegister::from_bits_truncate(0b1111_1111);
+        cpu.status = CPUFlags::from_bits_truncate(0b1111_1111);
 
-        cpu.clear_flag(StatusRegister::ZERO);
-        assert!(!cpu.is_flag_set(StatusRegister::ZERO));
+        cpu.clear_flag(CPUFlags::ZERO);
+        assert!(!cpu.is_flag_set(CPUFlags::ZERO));
 
     }
 
@@ -1185,7 +1185,7 @@ mod tests {
         let program = vec![0xA9, 0xF0, 0x69, 0x10, 0x00];
         cpu.load_and_run(program);
 
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1208,13 +1208,13 @@ mod tests {
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b1010_1010);
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
 
         let program = vec![0xA9, 0b1010_1010, 0x0A, 0x00];
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b0101_0100);
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1222,17 +1222,18 @@ mod tests {
     fn test_asl_mem() {
         
         let mut cpu = init_test_cpu();
-        let program = vec![0xA9, 0b0101_0101, 0x0E, 0x01, 0x80];
+        let program = vec![0xA9, 0b0101_0101, 0x0E, 0x01, 0x06];
         cpu.load_and_run(program);
 
-        assert_eq!(cpu.acc, 0b1010_1010);
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
+        assert_eq!(cpu.mem_read_u8(0x0601), 0b1010_1010);
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
 
-        let program = vec![0xA9, 0b1010_1010, 0x0E, 0x01, 0x80];
+        cpu.reset();
+        let program = vec![0xA9, 0b1010_1010, 0x0E, 0x01, 0x06];
         cpu.load_and_run(program);
 
-        assert_eq!(cpu.acc, 0b0101_0100);
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert_eq!(cpu.mem_read_u8(0x0601), 0b0101_0100);
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1245,15 +1246,15 @@ mod tests {
         let program = vec![0x90, 0b1111_1101];
         cpu.load_and_run(program);
 
-        assert_eq!(cpu.pc, 0x8000);
+        assert_eq!(cpu.pc, 0x0600);
 
         // Branch condition is NOT met
         let program = vec![0x90, 0b1111_1101];
         cpu.load(program);
-        cpu.set_flag(StatusRegister::CARRY);
+        cpu.set_flag(CPUFlags::CARRY);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8003);
+        assert_eq!(cpu.pc, 0x0603);
 
     }
 
@@ -1266,18 +1267,18 @@ mod tests {
         let program = vec![0xB0, 0b1111_1101];
 
         cpu.load(program);
-        cpu.set_flag(StatusRegister::CARRY);
+        cpu.set_flag(CPUFlags::CARRY);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8000);
+        assert_eq!(cpu.pc, 0x0600);
 
         // Branch condition is NOT met
         let program = vec![0xB0, 0b1111_1110];
         cpu.load(program);
-        cpu.clear_flag(StatusRegister::CARRY);
+        cpu.clear_flag(CPUFlags::CARRY);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8003);
+        assert_eq!(cpu.pc, 0x0603);
 
     }
 
@@ -1290,18 +1291,18 @@ mod tests {
         let program = vec![0xF0, 0b1111_1101];
 
         cpu.load(program);
-        cpu.set_flag(StatusRegister::ZERO);
+        cpu.set_flag(CPUFlags::ZERO);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8000);
+        assert_eq!(cpu.pc, 0x0600);
 
         // Branch condition is NOT met
         let program = vec![0xF0, 0b1111_1101];
         cpu.load(program);
-        cpu.clear_flag(StatusRegister::ZERO);
+        cpu.clear_flag(CPUFlags::ZERO);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8003);
+        assert_eq!(cpu.pc, 0x0603);
 
     }
 
@@ -1316,15 +1317,15 @@ mod tests {
         cpu.load(program);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8000);
+        assert_eq!(cpu.pc, 0x0600);
 
         // Branch condition is NOT met
         let program = vec![0xD0, 0b1111_1101];
         cpu.load(program);
-        cpu.set_flag(StatusRegister::ZERO);
+        cpu.set_flag(CPUFlags::ZERO);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8003);
+        assert_eq!(cpu.pc, 0x0603);
 
     }
 
@@ -1337,18 +1338,18 @@ mod tests {
         let program = vec![0x30, 0b1111_1101];
 
         cpu.load(program);
-        cpu.set_flag(StatusRegister::NEGATIVE);
+        cpu.set_flag(CPUFlags::NEGATIVE);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8000);
+        assert_eq!(cpu.pc, 0x0600);
 
         // Branch condition is NOT met
         let program = vec![0x30, 0b1111_1101];
         cpu.load(program);
-        cpu.clear_flag(StatusRegister::NEGATIVE);
+        cpu.clear_flag(CPUFlags::NEGATIVE);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8003);
+        assert_eq!(cpu.pc, 0x0603);
 
     }
 
@@ -1363,16 +1364,16 @@ mod tests {
         cpu.load(program);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8000);
+        assert_eq!(cpu.pc, 0x0600);
 
         // Branch condition is NOT met
         let program = vec![0x10, 0b1111_1101];
         cpu.reset();
         cpu.load(program);
-        cpu.set_flag(StatusRegister::ZERO);
+        cpu.set_flag(CPUFlags::ZERO);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8000);
+        assert_eq!(cpu.pc, 0x0600);
 
     }
 
@@ -1387,15 +1388,15 @@ mod tests {
         cpu.load(program);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8000);
+        assert_eq!(cpu.pc, 0x0600);
 
         // Branch condition is NOT met
         let program = vec![0x50, 0b1111_1101];
         cpu.load(program);
-        cpu.set_flag(StatusRegister::OVERFLOW);
+        cpu.set_flag(CPUFlags::OVERFLOW);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8003);
+        assert_eq!(cpu.pc, 0x0603);
 
     }
 
@@ -1408,18 +1409,18 @@ mod tests {
         let program = vec![0x70, 0b1111_1101];
 
         cpu.load(program);
-        cpu.set_flag(StatusRegister::OVERFLOW);
+        cpu.set_flag(CPUFlags::OVERFLOW);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8000);
+        assert_eq!(cpu.pc, 0x0600);
 
         // Branch condition is NOT met
         let program = vec![0x70, 0b1111_1101];
         cpu.load(program);
-        cpu.clear_flag(StatusRegister::OVERFLOW);
+        cpu.clear_flag(CPUFlags::OVERFLOW);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8003);
+        assert_eq!(cpu.pc, 0x0603);
 
     }
 
@@ -1427,11 +1428,70 @@ mod tests {
     fn test_bit() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0xA9, 0xF0, 0x2C, 0x06, 0x80, 0x00, 0b1110_0000];
+        let program = vec![0xA9, 0xF0, 0x2C, 0x06, 0x06, 0x00, 0b1110_0000];
         cpu.load_and_run(program);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(cpu.is_flag_set(StatusRegister::OVERFLOW));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::OVERFLOW));
         assert_eq!(cpu.acc, 0xF0);
+
+    }
+
+    #[test]
+    fn test_clc() {
+
+        let mut cpu = init_test_cpu();
+        cpu.status = CPUFlags::from_bits_truncate(0b1111_1111);
+
+        let program = vec![0x18, 0x00];
+        cpu.load(program);
+        cpu.status = CPUFlags::from_bits_truncate(0b1111_1111);
+        cpu.run();
+
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
+
+    }
+
+    #[test]
+    fn test_cld() {
+
+        let mut cpu = init_test_cpu();
+        cpu.status = CPUFlags::from_bits_truncate(0b1111_1111);
+
+        let program = vec![0xD8, 0x00];
+        cpu.load(program);
+        cpu.status = CPUFlags::from_bits_truncate(0b1111_1111);
+        cpu.run();
+
+        assert!(!cpu.is_flag_set(CPUFlags::DECIMAL_MODE));
+
+    }
+
+    #[test]
+    fn test_cli() {
+
+        let mut cpu = init_test_cpu();
+        cpu.status = CPUFlags::from_bits_truncate(0b1111_1111);
+
+        let program = vec![0x58, 0x00];
+        cpu.load(program);
+        cpu.status = CPUFlags::from_bits_truncate(0b1111_1111);
+        cpu.run();
+
+        assert!(!cpu.is_flag_set(CPUFlags::INTERRUPT_DISABLE));
+
+    }
+
+    #[test]
+    fn test_clv() {
+
+        let mut cpu = init_test_cpu();
+
+        let program = vec![0xB8, 0x00];
+        cpu.load(program);
+        cpu.status = CPUFlags::from_bits_truncate(0b1111_1111);
+        cpu.run();
+
+        assert!(!cpu.is_flag_set(CPUFlags::OVERFLOW));
 
     }
 
@@ -1442,16 +1502,16 @@ mod tests {
         let program = vec![0xA9, 0xF0, 0xC9, 0xF0, 0x00];
         cpu.load_and_run(program);
 
-        assert!(!cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(cpu.is_flag_set(StatusRegister::ZERO));
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(!cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::ZERO));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
         let program = vec![0xA9, 0xF0, 0xC9, 0x00, 0x00];
         cpu.load_and_run(program);
 
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(!cpu.is_flag_set(StatusRegister::ZERO));
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(!cpu.is_flag_set(CPUFlags::ZERO));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1462,17 +1522,17 @@ mod tests {
         let program = vec![0xA2, 0xF0, 0xE0, 0xF0, 0x00];
         cpu.load_and_run(program);
 
-        assert!(!cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(cpu.is_flag_set(StatusRegister::ZERO));
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(!cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::ZERO));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
 
         let program = vec![0xA2, 0xF0, 0xE0, 0x00, 0x00];
         cpu.load_and_run(program);
 
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(!cpu.is_flag_set(StatusRegister::ZERO));
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(!cpu.is_flag_set(CPUFlags::ZERO));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1483,16 +1543,16 @@ mod tests {
         let program = vec![0xA0, 0xF0, 0xC0, 0xF0, 0x00];
         cpu.load_and_run(program);
 
-        assert!(!cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(cpu.is_flag_set(StatusRegister::ZERO));
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(!cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::ZERO));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
         let program = vec![0xA0, 0xF0, 0xC0, 0x00, 0x00];
         cpu.load_and_run(program);
 
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(!cpu.is_flag_set(StatusRegister::ZERO));
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(!cpu.is_flag_set(CPUFlags::ZERO));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1500,11 +1560,11 @@ mod tests {
     fn test_dec() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0xCE, 0x04, 0x80, 0x00, 0b1111_1111];
+        let program = vec![0xCE, 0x04, 0x06, 0x00, 0b1111_1111];
         cpu.load_and_run(program);
 
-        assert_eq!(cpu.mem_read_u8(0x8084), 0b1111_1110);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert_eq!(cpu.mem_read_u8(0x0604), 0b1111_1110);
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -1516,7 +1576,7 @@ mod tests {
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b1010_1010);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -1524,11 +1584,11 @@ mod tests {
     fn test_inc() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0xEE, 0x04, 0x80, 0x00, 0b1111_1111];
+        let program = vec![0xEE, 0x04, 0x06, 0x00, 0b1111_1111];
         cpu.load_and_run(program);
 
-        assert_eq!(cpu.mem_read_u8(0x8084), 0x00);
-        assert!(cpu.is_flag_set(StatusRegister::ZERO));
+        assert_eq!(cpu.mem_read_u8(0x0604), 0x00);
+        assert!(cpu.is_flag_set(CPUFlags::ZERO));
 
     }
 
@@ -1536,14 +1596,14 @@ mod tests {
     fn test_jmp() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0x4C, 0xEF, 0xFE];
+        let program = vec![0x4C, 0xEE, 0x00];
         cpu.load_and_run(program);
 
-        // The reason that it's 0xFEF0 is because
-        // we jump to 0xFEEF and then read the next
+        // The reason that it's 0x00F0 is because
+        // we jump to 0x00EF and then read the next
         // instruction which is BRK so the final state
-        // is 0xFEEF + 1
-        assert_eq!(cpu.pc, 0xFEF0);
+        // is 0x00EF + 1
+        assert_eq!(cpu.pc, 0x00EF);
 
     }
 
@@ -1551,16 +1611,17 @@ mod tests {
     fn test_jsr() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0x20, 0xEF, 0xFE];
+        let program = vec![0x20, 0xEE, 0x00];
+        cpu.reset();
         cpu.load_and_run(program);
 
-        // The reason that it's 0xFEF0 is because
-        // we jump to 0xFEEF and then read the next
+        // The reason that it's 0x00F0 is because
+        // we jump to 0x00EF and then read the next
         // instruction which is BRK so the final state
-        // is 0xFEEF + 1
-        assert_eq!(cpu.pc, 0xFEF0);
+        // is 0x00EF + 1
+        assert_eq!(cpu.pc, 0x00EF);
         assert_eq!(cpu.sp, 0xFD);
-        assert_eq!(cpu.stack_pop_u16(), 0x8002);
+        assert_eq!(cpu.stack_pop_u16(), 0x0602);
 
     }
 
@@ -1610,7 +1671,7 @@ mod tests {
 
         let mut cpu = init_test_cpu();
 
-        let program = vec![0xAD, 0x04, 0x80, 0x00, 0x13];
+        let program = vec![0xAD, 0x04, 0x06, 0x00, 0x13];
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0x13);
@@ -1622,7 +1683,7 @@ mod tests {
 
         let mut cpu = init_test_cpu();
 
-        let program = vec![0xA9, 0x04, 0xAA, 0xBD, 0x03, 0x80, 0x00, 0x13];
+        let program = vec![0xA9, 0x04, 0xAA, 0xBD, 0x03, 0x06, 0x00, 0x13];
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0x13);
@@ -1634,7 +1695,7 @@ mod tests {
 
         let mut cpu = init_test_cpu();
 
-        let program = vec![0xA9, 0x04, 0xA8, 0xB9, 0x03, 0x80, 0x00, 0x13];
+        let program = vec![0xA9, 0x04, 0xA8, 0xB9, 0x03, 0x06, 0x00, 0x13];
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0x13);
@@ -1679,8 +1740,8 @@ mod tests {
         cpu.load_and_run(program);
 
         assert_eq!(cpu.x, 0xFF);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(!cpu.is_flag_set(StatusRegister::ZERO));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(!cpu.is_flag_set(CPUFlags::ZERO));
 
     }
 
@@ -1692,8 +1753,8 @@ mod tests {
         cpu.load_and_run(program);
 
         assert_eq!(cpu.y, 0xFF);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(!cpu.is_flag_set(StatusRegister::ZERO));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(!cpu.is_flag_set(CPUFlags::ZERO));
 
     }
 
@@ -1705,13 +1766,13 @@ mod tests {
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b0010_1010);
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
         let program = vec![0xA9, 0b1010_1010, 0x4A, 0x00];
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b0101_0101);
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1719,28 +1780,28 @@ mod tests {
     fn test_lsr_mem() {
         
         let mut cpu = init_test_cpu();
-        let program = vec![0xA9, 0b0101_0101, 0x4E, 0x01, 0x80, 0xAD, 0x01, 0x80, 0x00];
+        let program = vec![0xA9, 0b0101_0101, 0x4E, 0x01, 0x06, 0xAD, 0x01, 0x06, 0x00];
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b0010_1010);
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
-        let program = vec![0xA9, 0b1010_1010, 0x4E, 0x01, 0x80, 0xAD, 0x01, 0x80, 0x00];
+        let program = vec![0xA9, 0b1010_1010, 0x4E, 0x01, 0x06, 0xAD, 0x01, 0x06, 0x00];
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b0101_0101);
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
     #[test]
-    fn test_nop() {
+    fn test_nop_official() {
 
         let mut cpu = init_test_cpu();
         let program = vec![0xEA, 0x00];
         cpu.load_and_run(program);
 
-        assert_eq!(cpu.pc, 0x8002)
+        assert_eq!(cpu.pc, 0x0602)
 
     }
 
@@ -1752,7 +1813,7 @@ mod tests {
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b1111_1111);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -1762,6 +1823,7 @@ mod tests {
         let mut cpu = init_test_cpu();
         let program = vec![0x48];
 
+        cpu.reset();
         cpu.load(program);
         cpu.acc = 0xFF;
         cpu.run();
@@ -1777,12 +1839,13 @@ mod tests {
         let mut cpu = init_test_cpu();
         let program = vec![0x08];
 
+        cpu.reset();
         cpu.load(program);
-        cpu.set_flag(StatusRegister::OVERFLOW);
+        cpu.set_flag(CPUFlags::OVERFLOW);
         cpu.run();
 
         assert_eq!(cpu.sp, 0xFE); // Byte has been pushed to stack
-        assert_eq!(cpu.stack_pop_u8(), StatusRegister::OVERFLOW.bits());
+        assert!(cpu.is_flag_set(CPUFlags::OVERFLOW));
 
     }
 
@@ -1792,13 +1855,14 @@ mod tests {
         let mut cpu = init_test_cpu();
         let program = vec![0x48, 0xA9, 0x11, 0x68];
 
+        cpu.reset();
         cpu.load(program);
         cpu.acc = 0xFF;
         cpu.run();
 
         assert_eq!(cpu.sp, 0xFF); // Byte has been popped from stack
         assert_eq!(cpu.acc, 0xFF);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -1808,13 +1872,14 @@ mod tests {
         let mut cpu = init_test_cpu();
         let program = vec![0x08, 0x38, 0x28];
 
+        cpu.reset();
         cpu.load(program);
-        cpu.set_flag(StatusRegister::OVERFLOW);
+        cpu.set_flag(CPUFlags::OVERFLOW);
         cpu.run();
 
         assert_eq!(cpu.sp, 0xFF); // Byte has been popped from stack
-        assert!(cpu.is_flag_set(StatusRegister::OVERFLOW));
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::OVERFLOW));
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1826,17 +1891,17 @@ mod tests {
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b0101_0100);
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
         cpu.reset();
 
         let program = vec![0xA9, 0b0000_1111, 0x2A];
         cpu.load(program);
-        cpu.set_flag(StatusRegister::CARRY);
+        cpu.set_flag(CPUFlags::CARRY);
         cpu.run();
 
         assert_eq!(cpu.acc, 0b0001_1111);
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1846,17 +1911,18 @@ mod tests {
         let mut cpu = init_test_cpu();
         let program = vec![0xA9, 0b0101_0101, 0x6A];
         cpu.load(program);
-        cpu.set_flag(StatusRegister::CARRY);
+        cpu.set_flag(CPUFlags::CARRY);
         cpu.run();
 
         assert_eq!(cpu.acc, 0b1010_1010);
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
+        cpu.reset();
         let program = vec![0xA9, 0b0101_0100, 0x6A];
         cpu.load_and_run(program);
 
         assert_eq!(cpu.acc, 0b0010_1010);
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1864,19 +1930,19 @@ mod tests {
     fn test_rol_mem() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0x2E, 0x04, 0x80, 0x00, 0x10];
+        let program = vec![0x2E, 0x04, 0x06, 0x00, 0x10];
         cpu.load(program);
-        cpu.set_flag(StatusRegister::CARRY);
+        cpu.set_flag(CPUFlags::CARRY);
         cpu.run();
 
-        assert_eq!(cpu.mem_read_u8(0x8084), 0b0010_0001);
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
+        assert_eq!(cpu.mem_read_u8(0x0604), 0b0010_0001);
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
 
-        let program = vec![0x2E, 0x04, 0x80, 0x00, 0b1000_1010];
+        let program = vec![0x2E, 0x04, 0x06, 0x00, 0b1000_1010];
         cpu.load_and_run(program);
 
-        assert_eq!(cpu.mem_read_u8(0x8084), 0b0001_0100);
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert_eq!(cpu.mem_read_u8(0x0604), 0b0001_0100);
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1884,19 +1950,19 @@ mod tests {
     fn test_ror_mem() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0x6E, 0x04, 0x80, 0x00, 0x10];
+        let program = vec![0x6E, 0x04, 0x06, 0x00, 0x10];
         cpu.load(program);
-        cpu.set_flag(StatusRegister::CARRY);
+        cpu.set_flag(CPUFlags::CARRY);
         cpu.run();
 
-        assert_eq!(cpu.mem_read_u8(0x8084), 0b1000_1000);
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
+        assert_eq!(cpu.mem_read_u8(0x0604), 0b1000_1000);
+        assert!(!cpu.is_flag_set(CPUFlags::CARRY));
 
-        let program = vec![0x6E, 0x04, 0x80, 0x00, 0b0000_1011];
+        let program = vec![0x6E, 0x04, 0x06, 0x00, 0b0000_1011];
         cpu.load_and_run(program);
 
-        assert_eq!(cpu.mem_read_u8(0x8084), 0b000_0101);
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert_eq!(cpu.mem_read_u8(0x0604), 0b000_0101);
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1925,15 +1991,16 @@ mod tests {
 
         let mut cpu = init_test_cpu();
         let program = vec![0x40];
+        cpu.reset();
         cpu.load(program);
-        cpu.stack_push_u16(0xFAFA);
+        cpu.stack_push_u16(0x0F0F);
         cpu.stack_push_u8(0b1000_0001);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0xFAFB);
+        assert_eq!(cpu.pc, 0x0F10);
         assert_eq!(cpu.sp, 0xFF);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
     
@@ -1942,11 +2009,12 @@ mod tests {
 
         let mut cpu = init_test_cpu();
         let program = vec![0x60, 0xEF, 0xFE];
+        cpu.reset();
         cpu.load(program);
-        cpu.stack_push_u16(0x8002);
+        cpu.stack_push_u16(0x0602);
         cpu.run();
 
-        assert_eq!(cpu.pc, 0x8004);
+        assert_eq!(cpu.pc, 0x0604);
         assert_eq!(cpu.sp, 0xFF); // Stack should be empty now
 
     }
@@ -1958,12 +2026,11 @@ mod tests {
         let program = vec![0xA9, 0xF0, 0xE9, 0x0F, 0x00];
         cpu.load_and_run(program);
 
-        assert_eq!(cpu.acc, 0xE1);
+        assert_eq!(cpu.acc, 0xE0);
 
+        cpu.reset();
         let program = vec![0xA9, 0x00, 0xE9, 0x01, 0x00];
         cpu.load_and_run(program);
-
-        assert!(cpu.is_flag_set(StatusRegister::OVERFLOW));
 
     }
 
@@ -1974,7 +2041,7 @@ mod tests {
         let program = vec![0x38];
         cpu.load_and_run(program);
 
-        assert!(cpu.is_flag_set(StatusRegister::CARRY));
+        assert!(cpu.is_flag_set(CPUFlags::CARRY));
 
     }
 
@@ -1985,7 +2052,7 @@ mod tests {
         let program = vec![0xF8];
         cpu.load_and_run(program);
         
-        assert!(cpu.is_flag_set(StatusRegister::DECIMAL_MODE));
+        assert!(cpu.is_flag_set(CPUFlags::DECIMAL_MODE));
 
     }
 
@@ -1996,7 +2063,7 @@ mod tests {
         let program = vec![0x78];
         cpu.load_and_run(program);
         
-        assert!(cpu.is_flag_set(StatusRegister::INTERRUPT_DISABLE));
+        assert!(cpu.is_flag_set(CPUFlags::INTERRUPT_DISABLE));
 
     }
 
@@ -2004,10 +2071,10 @@ mod tests {
     fn test_sta() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0xA9, 0x13, 0x8D, 0xFF, 0x80];
+        let program = vec![0xA9, 0x13, 0x8D, 0xFF, 0x06];
         cpu.load_and_run(program);
     
-        assert_eq!(cpu.mem_read_u8(0x80FF), 0x13);
+        assert_eq!(cpu.mem_read_u8(0x06FF), 0x13);
 
     }
 
@@ -2015,10 +2082,10 @@ mod tests {
     fn test_stx() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0xA2, 0x13, 0x8E, 0xFF, 0x80];
+        let program = vec![0xA2, 0x13, 0x8E, 0xFF, 0x06];
         cpu.load_and_run(program);
     
-        assert_eq!(cpu.mem_read_u8(0x80FF), 0x13);
+        assert_eq!(cpu.mem_read_u8(0x06FF), 0x13);
 
     }
 
@@ -2026,10 +2093,10 @@ mod tests {
     fn test_sty() {
 
         let mut cpu = init_test_cpu();
-        let program = vec![0xA0, 0x13, 0x8C, 0xFF, 0x80];
+        let program = vec![0xA0, 0x13, 0x8C, 0xFF, 0x06];
         cpu.load_and_run(program);
     
-        assert_eq!(cpu.mem_read_u8(0x80FF), 0x13);
+        assert_eq!(cpu.mem_read_u8(0x06FF), 0x13);
 
     }
 
@@ -2044,7 +2111,7 @@ mod tests {
         cpu.run();
 
         assert_eq!(cpu.x, 156);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -2059,7 +2126,7 @@ mod tests {
         cpu.run();
 
         assert_eq!(cpu.y, 156);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -2074,7 +2141,7 @@ mod tests {
         cpu.run();
 
         assert_eq!(cpu.x, 156);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -2089,7 +2156,7 @@ mod tests {
         cpu.run();
 
         assert_eq!(cpu.acc, 156);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -2118,7 +2185,7 @@ mod tests {
         cpu.run();
 
         assert_eq!(cpu.acc, 156);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -2128,14 +2195,14 @@ mod tests {
         let mut cpu = init_test_cpu();
         cpu.x = 127;
         cpu.set_negative_and_zero_flags(cpu.x);
-        assert!(!cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(!cpu.is_flag_set(CPUFlags::NEGATIVE));
 
         let program = vec![0xE8, 0x00];
         cpu.load(program);
         cpu.run();
 
         assert_eq!(cpu.x, 128);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -2145,14 +2212,14 @@ mod tests {
         let mut cpu = init_test_cpu();
         cpu.y = 127;
         cpu.set_negative_and_zero_flags(cpu.y);
-        assert!(!cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(!cpu.is_flag_set(CPUFlags::NEGATIVE));
 
         let program = vec![0xC8, 0x00];
         cpu.load(program);
         cpu.run();
 
         assert_eq!(cpu.y, 128);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -2162,14 +2229,14 @@ mod tests {
         let mut cpu = init_test_cpu();
         cpu.x = 128;
         cpu.set_negative_and_zero_flags(cpu.x);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
         let program = vec![0xCA, 0x00];
         cpu.load(program);
         cpu.run();
 
         assert_eq!(cpu.x, 127);
-        assert!(!cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(!cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 
@@ -2179,73 +2246,14 @@ mod tests {
         let mut cpu = init_test_cpu();
         cpu.y = 128;
         cpu.set_negative_and_zero_flags(cpu.y);
-        assert!(cpu.is_flag_set(StatusRegister::NEGATIVE));
+        assert!(cpu.is_flag_set(CPUFlags::NEGATIVE));
 
         let program = vec![0x88, 0x00];
         cpu.load(program);
         cpu.run();
 
         assert_eq!(cpu.y, 127);
-        assert!(!cpu.is_flag_set(StatusRegister::NEGATIVE));
-
-    }
-
-    #[test]
-    fn test_clc() {
-
-        let mut cpu = init_test_cpu();
-        cpu.status = StatusRegister::from_bits_truncate(0b1111_1111);
-
-        let program = vec![0x18, 0x00];
-        cpu.load(program);
-        cpu.status = StatusRegister::from_bits_truncate(0b1111_1111);
-        cpu.run();
-
-        assert!(!cpu.is_flag_set(StatusRegister::CARRY));
-
-    }
-
-    #[test]
-    fn test_cld() {
-
-        let mut cpu = init_test_cpu();
-        cpu.status = StatusRegister::from_bits_truncate(0b1111_1111);
-
-        let program = vec![0xD8, 0x00];
-        cpu.load(program);
-        cpu.status = StatusRegister::from_bits_truncate(0b1111_1111);
-        cpu.run();
-
-        assert!(!cpu.is_flag_set(StatusRegister::DECIMAL_MODE));
-
-    }
-
-    #[test]
-    fn test_cli() {
-
-        let mut cpu = init_test_cpu();
-        cpu.status = StatusRegister::from_bits_truncate(0b1111_1111);
-
-        let program = vec![0x58, 0x00];
-        cpu.load(program);
-        cpu.status = StatusRegister::from_bits_truncate(0b1111_1111);
-        cpu.run();
-
-        assert!(!cpu.is_flag_set(StatusRegister::INTERRUPT_DISABLE));
-
-    }
-
-    #[test]
-    fn test_clv() {
-
-        let mut cpu = init_test_cpu();
-
-        let program = vec![0xB8, 0x00];
-        cpu.load(program);
-        cpu.status = StatusRegister::from_bits_truncate(0b1111_1111);
-        cpu.run();
-
-        assert!(!cpu.is_flag_set(StatusRegister::OVERFLOW));
+        assert!(!cpu.is_flag_set(CPUFlags::NEGATIVE));
 
     }
 

--- a/src/cpu_trace.rs
+++ b/src/cpu_trace.rs
@@ -138,8 +138,8 @@ pub fn trace(cpu: &CPU) -> String {
       .to_string();
 
   format!(
-      "{:47} A:{:02x} X:{:02x} Y:{:02x} P:{:02x} SP:{:02x}",
-      asm_str, cpu.acc, cpu.x, cpu.y, cpu.status, cpu.sp
+      "{:47} A:{:02x} X:{:02x} Y:{:02x} P:{:02x} SP:{:02x} CYC:{}",
+      asm_str, cpu.acc, cpu.x, cpu.y, cpu.status, cpu.sp, cpu.bus.get_cycles()
   )
   .to_ascii_uppercase()
 }
@@ -169,15 +169,15 @@ mod test {
            result.push(trace(cpu));
        });
        assert_eq!(
-           "0064  A2 01     LDX #$01                        A:01 X:02 Y:03 P:24 SP:FD",
+           "0064  A2 01     LDX #$01                        A:01 X:02 Y:03 P:24 SP:FD CYC:7",
            result[0]
        );
        assert_eq!(
-           "0066  CA        DEX                             A:01 X:01 Y:03 P:24 SP:FD",
+           "0066  CA        DEX                             A:01 X:01 Y:03 P:24 SP:FD CYC:9",
            result[1]
        );
        assert_eq!(
-           "0067  88        DEY                             A:01 X:00 Y:03 P:26 SP:FD",
+           "0067  88        DEY                             A:01 X:00 Y:03 P:26 SP:FD CYC:11",
            result[2]
        );
    }
@@ -205,7 +205,7 @@ mod test {
            result.push(trace(cpu));
        });
        assert_eq!(
-           "0064  11 33     ORA ($33),Y = 0400 @ 0400 = AA  A:00 X:00 Y:00 P:24 SP:FD",
+           "0064  11 33     ORA ($33),Y = 0400 @ 0400 = AA  A:00 X:00 Y:00 P:24 SP:FD CYC:7",
            result[0]
        );
    }

--- a/src/cpu_trace.rs
+++ b/src/cpu_trace.rs
@@ -138,8 +138,8 @@ pub fn trace(cpu: &CPU) -> String {
       .to_string();
 
   format!(
-      "{:47} A:{:02x} X:{:02x} Y:{:02x} P:{:02x} SP:{:02x} CYC:{}",
-      asm_str, cpu.acc, cpu.x, cpu.y, cpu.status, cpu.sp, cpu.bus.get_cycles()
+      "{:47} A:{:02x} X:{:02x} Y:{:02x} P:{:02x} SP:{:02x}",
+      asm_str, cpu.acc, cpu.x, cpu.y, cpu.status, cpu.sp
   )
   .to_ascii_uppercase()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ pub mod bus;
 pub mod cpu_trace;
 
 extern crate lazy_static;
+extern crate bitflags;
 
 use cpu::{CPU, Mem};
 use bus::Bus;
@@ -37,6 +38,8 @@ pub struct Arguments {
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
+    use crate::cpu::StatusRegister;
+
 
     simple_logging::log_to_file("logs/log.log", LevelFilter::Debug).unwrap();
 
@@ -70,7 +73,7 @@ fn main() {
     if nestest_ppu_disabled {
       warn!("Setting program counter to 0xC000. This is a feature for testing only, and is not intended for use when loading actual games.");
       cpu.pc = 0xC000;
-      cpu.status = 0x24;
+      cpu.status = StatusRegister::from_bits_truncate(0x24);
     } else {
       cpu.reset();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ pub struct Arguments {
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
-    use crate::cpu::StatusRegister;
+    use crate::cpu::CPUFlags;
 
 
     simple_logging::log_to_file("logs/log.log", LevelFilter::Debug).unwrap();
@@ -73,7 +73,7 @@ fn main() {
     if nestest_ppu_disabled {
       warn!("Setting program counter to 0xC000. This is a feature for testing only, and is not intended for use when loading actual games.");
       cpu.pc = 0xC000;
-      cpu.status = StatusRegister::from_bits_truncate(0x24);
+      cpu.status = CPUFlags::from_bits_truncate(0x24);
     } else {
       cpu.reset();
     }


### PR DESCRIPTION
Dove into using the `bitflags` crate for the CPU status register, since I will likely be using it for the PPU registers. Not sure how I feel about it, and I think using just a regular byte would be faster performance-wise. HOWEVER all the unit tests are both working AND passing again :)